### PR TITLE
Add Login and Signup UI changes and Prevent unauthenticated user from using some commands 

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -18,4 +18,6 @@ public class Messages {
         "Invalid deliveryman command format! \n%1$s";
     public static final String MESSAGE_DELIVERYMEN_LISTED_OVERVIEW = "%1$d deliverymen listed!";
 
+    public static final String MESSAGE_REQUIRE_LOGIN = "Please login first!";
+
 }

--- a/src/main/java/seedu/address/commons/events/model/UserLoggedInEvent.java
+++ b/src/main/java/seedu/address/commons/events/model/UserLoggedInEvent.java
@@ -1,0 +1,21 @@
+package seedu.address.commons.events.model;
+
+import seedu.address.commons.events.BaseEvent;
+import seedu.address.model.user.User;
+
+/**
+ * Indicates the user has logged in
+ */
+public class UserLoggedInEvent extends BaseEvent {
+
+    public final User data;
+
+    public UserLoggedInEvent(User data) {
+        this.data = data;
+    }
+
+    @Override
+    public String toString() {
+        return "User " + data.getUsername() + " have logged in";
+    }
+}

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -1,5 +1,7 @@
 package seedu.address.logic;
 
+import static seedu.address.commons.core.Messages.MESSAGE_REQUIRE_LOGIN;
+
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -7,6 +9,10 @@ import seedu.address.commons.core.ComponentManager;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.LoginCommand;
+import seedu.address.logic.commands.SignUpCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.OrderBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -34,7 +40,11 @@ public class LogicManager extends ComponentManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         try {
             Command command = orderBookParser.parseCommand(commandText);
-            return command.execute(model, history);
+            if (model.isUserLoggedIn() || isNotAuthenticatedCommand(command)) {
+                return command.execute(model, history);
+            } else {
+                return new CommandResult(MESSAGE_REQUIRE_LOGIN);
+            }
         } finally {
             history.add(commandText);
         }
@@ -48,5 +58,11 @@ public class LogicManager extends ComponentManager implements Logic {
     @Override
     public ListElementPointer getHistorySnapshot() {
         return new ListElementPointer(history.getHistory());
+    }
+
+    private boolean isNotAuthenticatedCommand(Command command) {
+        return command instanceof LoginCommand || command instanceof SignUpCommand
+                || command instanceof HelpCommand || command instanceof HistoryCommand;
+
     }
 }

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -22,8 +22,8 @@ public class LoginCommand extends Command {
 
     public static final String MESSAGE_ALREADY_LOGGED_IN = "You are already logged in as %1$s";
 
-    public static final String MESSAGE_REDIRECT_TO_LOGOUT = "Please logout before attempting to login to another " +
-            "account";
+    public static final String MESSAGE_REDIRECT_TO_LOGOUT = "Please logout before attempting to login to another "
+            + "account";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Login to FoodZoom. "
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -48,7 +48,7 @@ public class LoginCommand extends Command {
         requireNonNull(model);
         if (model.isUserLoggedIn()) {
             User loggedInUser = model.getLoggedInUserDetails();
-            String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser)
+            String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser.getUsername())
                     + "\n"
                     + MESSAGE_REDIRECT_TO_LOGOUT;
             return new CommandResult(result);

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -20,6 +20,11 @@ public class LoginCommand extends Command {
 
     public static final String MESSAGE_FAILURE = "Login Failure for %1$s";
 
+    public static final String MESSAGE_ALREADY_LOGGED_IN = "You are already logged in as %1$s";
+
+    public static final String MESSAGE_REDIRECT_TO_LOGOUT = "Please logout before attempting to login to another " +
+            "account";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Login to FoodZoom. "
             + "Parameters: "
             + PREFIX_USERNAME + "USERNAME "
@@ -41,6 +46,14 @@ public class LoginCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        if (model.isUserLoggedIn()) {
+            User loggedInUser = model.getLoggedInUserDetails();
+            String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser)
+                    + "\n"
+                    + MESSAGE_REDIRECT_TO_LOGOUT;
+            return new CommandResult(result);
+        }
+
         if (model.isRegisteredUser(toLogin)) {
             model.storeUserInSession(toLogin);
             return new CommandResult(String.format(MESSAGE_SUCCESS, toLogin));

--- a/src/main/java/seedu/address/logic/commands/SignUpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SignUpCommand.java
@@ -28,6 +28,7 @@ public class SignUpCommand extends Command {
             + PREFIX_PASSWORD + "johndoepassword";
 
     public static final String MESSAGE_SUCCESS = "New user added: %1$s";
+    public static final String MESSAGE_LOGGED_IN = "You have been logged into FoodZoom.";
     public static final String MESSAGE_DUPLICATE_USER = "This user already exists in FoodZoom.";
 
     private final User toAdd;
@@ -50,7 +51,10 @@ public class SignUpCommand extends Command {
         model.addUser(toAdd);
         model.storeUserInSession(toAdd);
         model.commitUsersList();
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        String result = String.format(MESSAGE_SUCCESS, toAdd)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
+        return new CommandResult(result);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/SignUpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SignUpCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_ALREADY_LOGGED_IN;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
@@ -44,6 +46,14 @@ public class SignUpCommand extends Command {
     @Override
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
+        if (model.isUserLoggedIn()) {
+            User loggedInUser = model.getLoggedInUserDetails();
+            String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser.getUsername())
+                    + "\n"
+                    + MESSAGE_REDIRECT_TO_LOGOUT;
+            return new CommandResult(result);
+        }
+
         if (model.hasUser(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_USER);
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -132,6 +132,13 @@ public class ModelManager extends ComponentManager implements Model {
         raise(new DeliverymenListChangedEvent(versionedDeliverymenList));
     }
 
+    /**
+     * Raises an event to indicate the model has changed
+     */
+    private void indicateUsersListChanged() {
+        raise(new UsersListChangedEvent(versionedUsersList));
+    }
+    
     @Override
     public boolean hasOrder(Order order) {
         requireNonNull(order);
@@ -345,13 +352,6 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public User getLoggedInUserDetails() {
         return userSession.getLoggedInUserDetails();
-    }
-
-    /**
-     * Raises an event to indicate the model has changed
-     */
-    private void indicateUsersListChanged() {
-        raise(new UsersListChangedEvent(versionedUsersList));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.events.model.DeliverymenListChangedEvent;
 import seedu.address.commons.events.model.OrderBookChangedEvent;
 import seedu.address.commons.events.model.RouteListChangedEvent;
+import seedu.address.commons.events.model.UserLoggedInEvent;
 import seedu.address.commons.events.model.UsersListChangedEvent;
 import seedu.address.model.deliveryman.Deliveryman;
 import seedu.address.model.deliveryman.DeliverymenList;
@@ -138,7 +139,15 @@ public class ModelManager extends ComponentManager implements Model {
     private void indicateUsersListChanged() {
         raise(new UsersListChangedEvent(versionedUsersList));
     }
-    
+
+    /**
+     * Raises an event to indicate user have logged in.
+     */
+    private void indicateUserLoggedIn(User user) {
+        raise(new UserLoggedInEvent(user));
+    }
+
+
     @Override
     public boolean hasOrder(Order order) {
         requireNonNull(order);
@@ -347,6 +356,7 @@ public class ModelManager extends ComponentManager implements Model {
     @Override
     public void storeUserInSession(User user) {
         userSession.setUserSession(user);
+        indicateUserLoggedIn(user);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -133,14 +133,17 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(logic);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+
+        orderListPanel = new OrderListPanel(logic.getFilteredOrderList());
+        orderListPanelPlaceholder.getChildren().add(orderListPanel.getRoot());
+        orderListPanelPlaceholder.setVisible(false);
     }
 
     /**
      * Display order list panel after login successful.
      */
     void displayOrderListPanel() {
-        orderListPanel = new OrderListPanel(logic.getFilteredOrderList());
-        orderListPanelPlaceholder.getChildren().add(orderListPanel.getRoot());
+        orderListPanelPlaceholder.setVisible(true);
     }
 
     void hide() {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -15,6 +15,7 @@ import javafx.stage.Stage;
 import seedu.address.commons.core.Config;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.model.UserLoggedInEvent;
 import seedu.address.commons.events.ui.ExitAppRequestEvent;
 import seedu.address.commons.events.ui.ShowHelpRequestEvent;
 import seedu.address.logic.Logic;
@@ -27,6 +28,7 @@ import seedu.address.model.UserPrefs;
 public class MainWindow extends UiPart<Stage> {
 
     private static final String FXML = "MainWindow.fxml";
+    private static final String DISPLAYING_ORDER_LIST_PANEL = "Displaying Order list panel";
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
@@ -123,9 +125,6 @@ public class MainWindow extends UiPart<Stage> {
         browserPanel = new BrowserPanel();
         browserPlaceholder.getChildren().add(browserPanel.getRoot());
 
-        orderListPanel = new OrderListPanel(logic.getFilteredOrderList());
-        orderListPanelPlaceholder.getChildren().add(orderListPanel.getRoot());
-
         ResultDisplay resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
 
@@ -134,6 +133,14 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(logic);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+    }
+
+    /**
+     * Display order list panel after login successful.
+     */
+    void displayOrderListPanel() {
+        orderListPanel = new OrderListPanel(logic.getFilteredOrderList());
+        orderListPanelPlaceholder.getChildren().add(orderListPanel.getRoot());
     }
 
     void hide() {
@@ -200,5 +207,11 @@ public class MainWindow extends UiPart<Stage> {
     private void handleShowHelpEvent(ShowHelpRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         handleHelp();
+    }
+
+    @Subscribe
+    private void handleUserLoggedInEvent(UserLoggedInEvent event) {
+        logger.info(DISPLAYING_ORDER_LIST_PANEL);
+        displayOrderListPanel();
     }
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -3,6 +3,12 @@ package seedu.address.logic;
 import static org.junit.Assert.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,6 +16,7 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.SignUpCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.order.ListCommand;
 import seedu.address.logic.commands.order.OrderCommand;
@@ -17,6 +24,8 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.user.User;
+import seedu.address.testutil.user.UserBuilder;
 
 
 public class LogicManagerTest {
@@ -26,31 +35,59 @@ public class LogicManagerTest {
     private Model model = new ModelManager();
     private Logic logic = new LogicManager(model);
 
+    private String signupCommandWord = SignUpCommand.COMMAND_WORD + " ";
+    private String signUpCommand = signupCommandWord + PREFIX_NAME + VALID_MANAGER_NAME_IDA
+            + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
+            + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+
+    public LogicManagerTest() {
+        signUp();
+    }
+
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
         assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
-        assertHistoryCorrect(invalidCommand);
+        assertHistoryCorrect(invalidCommand, signUpCommand);
     }
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
         String deleteCommand = "/order delete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
-        assertHistoryCorrect(deleteCommand);
+        assertHistoryCorrect(deleteCommand, signUpCommand);
     }
 
     @Test
     public void execute_validCommand_success() {
         String listCommand = OrderCommand.COMMAND_WORD + " " + ListCommand.COMMAND_WORD;
         assertCommandSuccess(listCommand, ListCommand.MESSAGE_SUCCESS, model);
-        assertHistoryCorrect(listCommand);
+        assertHistoryCorrect(listCommand, signUpCommand);
     }
 
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         logic.getFilteredOrderList().remove(0);
+    }
+
+    /**
+     * Signup a user to use the commands.
+     */
+    private void signUp() {
+        String signupCommand = SignUpCommand.COMMAND_WORD + " ";
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_IDA
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+
+        User ida = new UserBuilder()
+                .withName(VALID_MANAGER_NAME_IDA)
+                .withUsername(VALID_MANAGER_USERNAME_IDA)
+                .withPassword(VALID_MANAGER_PASSWORD_IDA)
+                .build();
+
+        String expectedResultMessage = String.format(SignUpCommand.MESSAGE_SUCCESS, ida);
+        assertCommandSuccess(command, expectedResultMessage, model);
     }
 
     /**
@@ -88,8 +125,8 @@ public class LogicManagerTest {
      */
     private void assertCommandFailure(String inputCommand, Class<?> expectedException, String expectedMessage) {
         Model expectedModel = new ModelManager(model.getOrderBook(), model.getRouteList(),
-            model.getUsersList(), model.getDeliverymenList(), new UserPrefs());
-        assertCommandBehavior(expectedException, inputCommand, expectedMessage, expectedModel);
+                model.getUsersList(), model.getDeliverymenList(), new UserPrefs());
+        assertCommandBehavior(expectedException, inputCommand, expectedMessage, model);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -6,6 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_LOGGED_IN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
@@ -86,7 +87,9 @@ public class LogicManagerTest {
                 .withPassword(VALID_MANAGER_PASSWORD_IDA)
                 .build();
 
-        String expectedResultMessage = String.format(SignUpCommand.MESSAGE_SUCCESS, ida);
+        String expectedResultMessage = String.format(SignUpCommand.MESSAGE_SUCCESS, ida)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
         assertCommandSuccess(command, expectedResultMessage, model);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -75,10 +75,13 @@ public class CommandTestUtil {
 
     public static final String VALID_MANAGER_NAME_ALICE = "Alice Pauline";
     public static final String VALID_MANAGER_NAME_BENSON = "Benson Meier";
+    public static final String VALID_MANAGER_NAME_IDA = "Ida Mueller";
     public static final String VALID_MANAGER_USERNAME_ALICE = "alicepauline";
     public static final String VALID_MANAGER_USERNAME_BENSON = "bensonmeier";
+    public static final String VALID_MANAGER_USERNAME_IDA = "idamueller";
     public static final String VALID_MANAGER_PASSWORD_ALICE = "alicepauline01";
     public static final String VALID_MANAGER_PASSWORD_BENSON = "bensonmeier02";
+    public static final String VALID_MANAGER_PASSWORD_IDA = "idamueller05";
 
     public static final String NAME_DESC_ALICE = " " + PREFIX_NAME + VALID_MANAGER_NAME_ALICE;
     public static final String NAME_DESC_BENSON = " " + PREFIX_NAME + VALID_MANAGER_NAME_BENSON;

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -76,12 +76,18 @@ public class CommandTestUtil {
     public static final String VALID_MANAGER_NAME_ALICE = "Alice Pauline";
     public static final String VALID_MANAGER_NAME_BENSON = "Benson Meier";
     public static final String VALID_MANAGER_NAME_IDA = "Ida Mueller";
+    public static final String VALID_MANAGER_NAME_HOON = "Hoon Meier";
+    public static final String VALID_MANAGER_NAME_KENNY = "Kenny Chan";
     public static final String VALID_MANAGER_USERNAME_ALICE = "alicepauline";
     public static final String VALID_MANAGER_USERNAME_BENSON = "bensonmeier";
     public static final String VALID_MANAGER_USERNAME_IDA = "idamueller";
+    public static final String VALID_MANAGER_USERNAME_HOON = "hoonmeier";
+    public static final String VALID_MANAGER_USERNAME_KENNY = "kennychan";
     public static final String VALID_MANAGER_PASSWORD_ALICE = "alicepauline01";
     public static final String VALID_MANAGER_PASSWORD_BENSON = "bensonmeier02";
     public static final String VALID_MANAGER_PASSWORD_IDA = "idamueller05";
+    public static final String VALID_MANAGER_PASSWORD_HOON = "hoonmeier04";
+    public static final String VALID_MANAGER_PASSWORD_KENNY = "kennychan06";
 
     public static final String NAME_DESC_ALICE = " " + PREFIX_NAME + VALID_MANAGER_NAME_ALICE;
     public static final String NAME_DESC_BENSON = " " + PREFIX_NAME + VALID_MANAGER_NAME_BENSON;

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -58,7 +58,7 @@ public class LoginCommandTest {
                 .build();
 
         commandResult = new LoginCommand(anotherUser).execute(model, commandHistory);
-        String expectedResult = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN, validUser)
+        String expectedResult = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN, validUser.getUsername())
                 + "\n"
                 + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
         assertEquals(expectedResult, commandResult.feedbackToUser);

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -41,6 +41,30 @@ public class LoginCommandTest {
     }
 
     @Test
+    public void execute_userAcceptedByModel_cannotLoginAfterLogin() throws Exception {
+        User validUser = new UserBuilder()
+                .withUsername(VALID_MANAGER_USERNAME_ALICE)
+                .withPassword(VALID_MANAGER_PASSWORD_ALICE)
+                .build();
+
+        CommandResult commandResult = new LoginCommand(validUser).execute(model, commandHistory);
+
+        assertEquals(String.format(LoginCommand.MESSAGE_SUCCESS, validUser), commandResult.feedbackToUser);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
+
+        User anotherUser = new UserBuilder()
+                .withUsername(VALID_MANAGER_USERNAME_BENSON)
+                .withPassword(VALID_MANAGER_PASSWORD_BENSON)
+                .build();
+
+        commandResult = new LoginCommand(anotherUser).execute(model, commandHistory);
+        String expectedResult = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN, validUser)
+                + "\n"
+                + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
+        assertEquals(expectedResult, commandResult.feedbackToUser);
+    }
+
+    @Test
     public void execute_userAcceptedByModel_loginSuccessful() throws Exception {
         User validUser = new UserBuilder()
                 .withUsername(VALID_MANAGER_USERNAME_ALICE)

--- a/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWOR
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_BENSON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_BENSON;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_ALREADY_LOGGED_IN;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_LOGGED_IN;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.TypicalDeliverymen.getTypicalDeliverymenList;
@@ -16,6 +18,7 @@ import static seedu.address.testutil.TypicalOrders.getTypicalOrderBook;
 import static seedu.address.testutil.TypicalRoutes.getTypicalRouteList;
 import static seedu.address.testutil.user.TypicalUsers.BENSON_MANAGER;
 import static seedu.address.testutil.user.TypicalUsers.HOON_MANAGER;
+import static seedu.address.testutil.user.TypicalUsers.IDA_MANAGER;
 import static seedu.address.testutil.user.TypicalUsers.getTypicalUsersList;
 
 import org.junit.Rule;
@@ -45,6 +48,28 @@ public class SignUpCommandTest {
     public void constructor_nullUser_throwsNullPointerException() {
         thrown.expect(NullPointerException.class);
         new SignUpCommand(null);
+    }
+
+    @Test
+    public void execute_userAcceptedByModel_cannotSignupAfterSignup() throws Exception {
+        User validUser = new UserBuilder(HOON_MANAGER).build();
+
+        CommandResult commandResult = new SignUpCommand(validUser).execute(model, commandHistory);
+
+        String expectedResult = String.format(MESSAGE_SUCCESS, validUser)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
+        assertEquals(expectedResult, commandResult.feedbackToUser);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
+
+        User anotherUser = new UserBuilder(IDA_MANAGER).build();
+        commandResult = new SignUpCommand(anotherUser).execute(model, commandHistory);
+        expectedResult = String.format(MESSAGE_ALREADY_LOGGED_IN, validUser.getUsername())
+                + "\n"
+                + MESSAGE_REDIRECT_TO_LOGOUT;
+        assertEquals(expectedResult, commandResult.feedbackToUser);
+        assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
@@ -9,6 +9,8 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWOR
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_BENSON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_BENSON;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_LOGGED_IN;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.TypicalDeliverymen.getTypicalDeliverymenList;
 import static seedu.address.testutil.TypicalOrders.getTypicalOrderBook;
 import static seedu.address.testutil.TypicalRoutes.getTypicalRouteList;
@@ -51,7 +53,10 @@ public class SignUpCommandTest {
 
         CommandResult commandResult = new SignUpCommand(validUser).execute(model, commandHistory);
 
-        assertEquals(String.format(SignUpCommand.MESSAGE_SUCCESS, validUser), commandResult.feedbackToUser);
+        String expectedResult = String.format(MESSAGE_SUCCESS, validUser)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
+        assertEquals(expectedResult, commandResult.feedbackToUser);
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
     }
 

--- a/src/test/java/systemtests/AddCommandSystemTest.java
+++ b/src/test/java/systemtests/AddCommandSystemTest.java
@@ -16,8 +16,12 @@ import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 import static seedu.address.testutil.TypicalOrders.ALICE;
 import static seedu.address.testutil.TypicalOrders.AMY;
 import static seedu.address.testutil.TypicalOrders.BOB;
@@ -28,6 +32,7 @@ import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.order.AddCommand;
@@ -48,6 +53,12 @@ public class AddCommandSystemTest extends OrderBookSystemTest {
     public void add() {
         Model model = getModel();
 
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         /* ------------------------ Perform add operations on the shown unfiltered list ----------------------------- */
 
         /* Case: add an order to a non-empty address book, command with leading spaces and trailing spaces
@@ -55,7 +66,7 @@ public class AddCommandSystemTest extends OrderBookSystemTest {
          */
         Order toAdd = AMY;
         String addCommand = OrderCommand.COMMAND_WORD + " " + AddCommand.COMMAND_WORD;
-        String command = "   " + addCommand + "  " + NAME_DESC_AMY + "  " + PHONE_DESC_AMY + " "
+        command = "   " + addCommand + "  " + NAME_DESC_AMY + "  " + PHONE_DESC_AMY + " "
                 + "   " + ADDRESS_DESC_AMY + "   " + DATE_DESC_AMY + "  " + FOOD_DESC_BURGER + " ";
         assertCommandSuccess(command, toAdd);
 

--- a/src/test/java/systemtests/ClearCommandSystemTest.java
+++ b/src/test/java/systemtests/ClearCommandSystemTest.java
@@ -1,10 +1,15 @@
 package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 
 import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.order.ClearCommand;
@@ -18,6 +23,12 @@ public class ClearCommandSystemTest extends OrderBookSystemTest {
     public void clear() {
         final Model defaultModel = getModel();
 
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         String clearCommand = OrderCommand.COMMAND_WORD + " " + ClearCommand.COMMAND_WORD;
 
         /* Case: clear non-empty address book, command with leading spaces and trailing alphanumeric characters and
@@ -27,7 +38,7 @@ public class ClearCommandSystemTest extends OrderBookSystemTest {
         assertSelectedCardUnchanged();
 
         /* Case: undo clearing address book -> original address book restored */
-        String command = UndoCommand.COMMAND_WORD;
+        command = UndoCommand.COMMAND_WORD;
         String expectedResultMessage = UndoCommand.MESSAGE_SUCCESS;
         assertCommandSuccess(command, expectedResultMessage, defaultModel);
         assertSelectedCardUnchanged();

--- a/src/test/java/systemtests/DeleteCommandSystemTest.java
+++ b/src/test/java/systemtests/DeleteCommandSystemTest.java
@@ -2,7 +2,11 @@ package systemtests;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.order.DeleteCommand.MESSAGE_DELETE_ORDER_SUCCESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 import static seedu.address.testutil.TestUtil.getLastIndex;
 import static seedu.address.testutil.TestUtil.getMidIndex;
 import static seedu.address.testutil.TestUtil.getOrder;
@@ -12,6 +16,7 @@ import org.junit.Test;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.order.DeleteCommand;
@@ -29,9 +34,15 @@ public class DeleteCommandSystemTest extends OrderBookSystemTest {
     public void delete() {
         /* ----------------- Performing delete operation while an unfiltered list is being shown -------------------- */
 
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         /* Case: delete the first person in the list, command with leading spaces and trailing spaces -> deleted */
         Model expectedModel = getModel();
-        String command = "     " + DELETE_COMMAND + "      " + INDEX_FIRST.getOneBased() + "       ";
+        command = "     " + DELETE_COMMAND + "      " + INDEX_FIRST.getOneBased() + "       ";
         Order deletedOrder = removeOrder(expectedModel, INDEX_FIRST);
         String expectedResultMessage = String.format(MESSAGE_DELETE_ORDER_SUCCESS, deletedOrder);
         assertCommandSuccess(command, expectedModel, expectedResultMessage);

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -4,10 +4,14 @@ import static org.junit.Assert.assertFalse;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ORDER_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_ORDERS_LISTED_OVERVIEW;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FOOD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 import static seedu.address.testutil.TypicalOrders.BENSON;
 import static seedu.address.testutil.TypicalOrders.CARL;
 import static seedu.address.testutil.TypicalOrders.DANIEL;
@@ -20,6 +24,7 @@ import java.util.List;
 import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.order.DeleteCommand;
@@ -35,10 +40,16 @@ public class FindCommandSystemTest extends OrderBookSystemTest {
     public void find() {
         String findCommand = OrderCommand.COMMAND_WORD + " " + FindCommand.COMMAND_WORD;
 
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         /* Case: find multiple persons in order book by name, command with leading spaces and trailing spaces
          * -> 2 orders found
          */
-        String command = "   " + findCommand + " " + KEYWORD_NAME_MATCHING_MEIER + "   ";
+        command = "   " + findCommand + " " + KEYWORD_NAME_MATCHING_MEIER + "   ";
         Model expectedModel = getModel();
         ModelHelper.setFilteredList(expectedModel, BENSON, DANIEL); // first names of Benson and Daniel are "Meier"
         assertCommandSuccess(command, expectedModel);

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -36,13 +36,6 @@ public class HelpCommandSystemTest extends OrderBookSystemTest {
 
     @Test
     public void openHelpWindow() {
-
-        /* Login */
-        String loginCommand = LoginCommand.COMMAND_WORD + " ";
-        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
-                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
-        executeCommand(command);
-
         //use accelerator
         getCommandBox().click();
         getMainMenu().openHelpWindowUsingAccelerator();
@@ -71,6 +64,12 @@ public class HelpCommandSystemTest extends OrderBookSystemTest {
         // open help window and give it focus
         executeCommand(HelpCommand.COMMAND_WORD);
         getMainWindowHandle().focus();
+
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
 
         // assert that while the help window is open the UI updates correctly for a command execution
         executeCommand(OrderCommand.COMMAND_WORD + " " + SelectCommand.COMMAND_WORD + " "

--- a/src/test/java/systemtests/HelpCommandSystemTest.java
+++ b/src/test/java/systemtests/HelpCommandSystemTest.java
@@ -4,6 +4,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import static seedu.address.ui.testutil.GuiTestAssert.assertListMatching;
 
@@ -12,6 +16,7 @@ import org.junit.Test;
 import guitests.GuiRobot;
 import guitests.guihandles.HelpWindowHandle;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.order.DeleteCommand;
 import seedu.address.logic.commands.order.OrderCommand;
 import seedu.address.logic.commands.order.SelectCommand;
@@ -31,6 +36,13 @@ public class HelpCommandSystemTest extends OrderBookSystemTest {
 
     @Test
     public void openHelpWindow() {
+
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         //use accelerator
         getCommandBox().click();
         getMainMenu().openHelpWindowUsingAccelerator();

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -1,0 +1,100 @@
+package systemtests;
+
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_BENSON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_FAILURE;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.LoginCommand;
+import seedu.address.model.Model;
+
+public class LoginCommandSystemTest extends OrderBookSystemTest {
+
+    @Test
+    public void login() {
+        Model expectedModel = getModel();
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+
+        /* Case: Successful login, correct username and password */
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        String expectedResultMessage = String.format(
+                MESSAGE_SUCCESS, "Username: " + VALID_MANAGER_USERNAME_ALICE);
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+
+
+
+    }
+
+    @Test
+    public void login_fail_wrongPassword() {
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        /* Case: Fail to login, wrong password */
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_BENSON;
+        String expectedResultMessage = String.format(
+                MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_ALICE);
+
+        System.out.println(expectedResultMessage);
+        assertCommandFailure(command, expectedResultMessage);
+    }
+
+    @Test
+    public void login_fail_userNotExist() {
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        /* Case: Fail to login, wrong password */
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+        String expectedResultMessage = String.format(
+                MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_IDA);
+
+        System.out.println(expectedResultMessage);
+        assertCommandFailure(command, expectedResultMessage);
+    }
+
+
+
+    /**
+     * Executes {@code command} and verifies that the command box displays an empty string, the result display
+     * box displays {@code Messages#MESSAGE_ORDERS_LISTED_OVERVIEW} with the number of people in the filtered list,
+     * and the model related components equal to {@code expectedModel}.
+     * These verifications are done by
+     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
+     * selected card updated accordingly, depending on {@code cardStatus}.
+     *
+     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertCommandBoxShowsDefaultStyle();
+        assertStatusBarUnchanged();
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
+     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
+     * These verifications are done by
+     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
+     * error style.
+     *
+     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertCommandBoxShowsDefaultStyle();
+        assertStatusBarUnchanged();
+    }
+}

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -2,9 +2,9 @@ package systemtests;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_BENSON;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_KENNY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_KENNY;
 import static seedu.address.logic.commands.LoginCommand.MESSAGE_FAILURE;
 import static seedu.address.logic.commands.LoginCommand.MESSAGE_SUCCESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
@@ -48,10 +48,10 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
         String loginCommand = LoginCommand.COMMAND_WORD + " ";
 
         /* Case: Fail to login, wrong password */
-        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
-                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_KENNY
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_KENNY;
         String expectedResultMessage = String.format(
-                MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_IDA);
+                MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_KENNY);
 
         assertCommandFailure(command, expectedResultMessage);
     }

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -36,7 +36,7 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
         command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_HOON
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_HOON;
         expectedResultMessage = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN,
-                "Username: " + VALID_MANAGER_USERNAME_ALICE) + "\n" + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
+                VALID_MANAGER_USERNAME_ALICE) + "\n" + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
     }
 

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -28,34 +28,31 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
         String expectedResultMessage = String.format(
                 MESSAGE_SUCCESS, "Username: " + VALID_MANAGER_USERNAME_ALICE);
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
-
-
-
     }
 
     @Test
     public void login_fail_wrongPassword() {
         String loginCommand = LoginCommand.COMMAND_WORD + " ";
+
         /* Case: Fail to login, wrong password */
         String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_BENSON;
         String expectedResultMessage = String.format(
                 MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_ALICE);
 
-        System.out.println(expectedResultMessage);
         assertCommandFailure(command, expectedResultMessage);
     }
 
     @Test
     public void login_fail_userNotExist() {
         String loginCommand = LoginCommand.COMMAND_WORD + " ";
+
         /* Case: Fail to login, wrong password */
         String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
         String expectedResultMessage = String.format(
                 MESSAGE_FAILURE, "Username: " + VALID_MANAGER_USERNAME_IDA);
 
-        System.out.println(expectedResultMessage);
         assertCommandFailure(command, expectedResultMessage);
     }
 

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -2,8 +2,10 @@ package systemtests;
 
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_BENSON;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_HOON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_KENNY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_HOON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_KENNY;
 import static seedu.address.logic.commands.LoginCommand.MESSAGE_FAILURE;
 import static seedu.address.logic.commands.LoginCommand.MESSAGE_SUCCESS;
@@ -16,6 +18,27 @@ import seedu.address.logic.commands.LoginCommand;
 import seedu.address.model.Model;
 
 public class LoginCommandSystemTest extends OrderBookSystemTest {
+
+
+    @Test
+    public void cannotLoginAfterLogin() {
+        Model expectedModel = getModel();
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+
+        /* Case: Successful login, correct username and password */
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        String expectedResultMessage = String.format(
+                MESSAGE_SUCCESS, "Username: " + VALID_MANAGER_USERNAME_ALICE);
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+
+        /* Case: Attempt to login after successful login */
+        command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_HOON
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_HOON;
+        expectedResultMessage = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN,
+                "Username: " + VALID_MANAGER_USERNAME_ALICE) + "\n" + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+    }
 
     @Test
     public void login() {

--- a/src/test/java/systemtests/SelectCommandSystemTest.java
+++ b/src/test/java/systemtests/SelectCommandSystemTest.java
@@ -4,7 +4,11 @@ import static org.junit.Assert.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.order.SelectCommand.MESSAGE_SELECT_ORDER_SUCCESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
 import static seedu.address.testutil.TestUtil.getLastIndex;
 import static seedu.address.testutil.TestUtil.getMidIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
@@ -12,6 +16,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
 import org.junit.Test;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.LoginCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.order.OrderCommand;
@@ -21,13 +26,20 @@ import seedu.address.model.Model;
 public class SelectCommandSystemTest extends OrderBookSystemTest {
     @Test
     public void select() {
+
+        /* Login */
+        String loginCommand = LoginCommand.COMMAND_WORD + " ";
+        String command = loginCommand + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+        executeCommand(command);
+
         String selectCommand = OrderCommand.COMMAND_WORD + " " + SelectCommand.COMMAND_WORD;
         /* ------------------------ Perform select operations on the shown unfiltered list -------------------------- */
 
         /* Case: select the first card in the person list, command with leading spaces and trailing spaces
          * -> selected
          */
-        String command = "   " + selectCommand + " " + INDEX_FIRST.getOneBased() + "   ";
+        command = "   " + selectCommand + " " + INDEX_FIRST.getOneBased() + "   ";
         assertCommandSuccess(command, INDEX_FIRST);
 
         /* Case: select the last card in the person list -> selected */

--- a/src/test/java/systemtests/SignUpCommandSystemTest.java
+++ b/src/test/java/systemtests/SignUpCommandSystemTest.java
@@ -4,11 +4,16 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PASSWORD_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_USERNAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_HOON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_HOON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_HOON;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_ALREADY_LOGGED_IN;
+import static seedu.address.logic.commands.LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_DUPLICATE_USER;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_LOGGED_IN;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_SUCCESS;
@@ -29,6 +34,42 @@ import seedu.address.testutil.user.UserBuilder;
 public class SignUpCommandSystemTest extends OrderBookSystemTest {
 
     private String signupCommand = SignUpCommand.COMMAND_WORD + " ";
+
+    @Test
+    public void cannotSignupAfterSignup() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_IDA
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+
+        User ida = new UserBuilder()
+                .withName(VALID_MANAGER_NAME_IDA)
+                .withUsername(VALID_MANAGER_USERNAME_IDA)
+                .withPassword(VALID_MANAGER_PASSWORD_IDA)
+                .build();
+
+        String expectedResultMessage = String.format(MESSAGE_SUCCESS, ida)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
+
+
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+
+        command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_HOON
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_HOON
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_HOON;
+
+        User hoon = new UserBuilder()
+                .withName(VALID_MANAGER_NAME_HOON)
+                .withUsername(VALID_MANAGER_USERNAME_HOON)
+                .withPassword(VALID_MANAGER_PASSWORD_HOON)
+                .build();
+
+        expectedResultMessage = String.format(MESSAGE_ALREADY_LOGGED_IN, ida.getUsername())
+                + "\n"
+                + MESSAGE_REDIRECT_TO_LOGOUT;
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+    }
 
     @Test
     public void signup_newUser_successful() {

--- a/src/test/java/systemtests/SignUpCommandSystemTest.java
+++ b/src/test/java/systemtests/SignUpCommandSystemTest.java
@@ -72,27 +72,6 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
     }
 
     @Test
-    public void signup_newUser_successful() {
-        Model expectedModel = getModel();
-        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_IDA
-                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
-                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
-
-        User ida = new UserBuilder()
-                .withName(VALID_MANAGER_NAME_IDA)
-                .withUsername(VALID_MANAGER_USERNAME_IDA)
-                .withPassword(VALID_MANAGER_PASSWORD_IDA)
-                .build();
-
-        String expectedResultMessage = String.format(MESSAGE_SUCCESS, ida)
-                + "\n"
-                + MESSAGE_LOGGED_IN;
-
-
-        assertCommandSuccess(command, expectedModel, expectedResultMessage);
-    }
-
-    @Test
     public void signup_exisitingUser_failure() {
         Model expectedModel = getModel();
         String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE

--- a/src/test/java/systemtests/SignUpCommandSystemTest.java
+++ b/src/test/java/systemtests/SignUpCommandSystemTest.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWOR
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_DUPLICATE_USER;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_LOGGED_IN;
 import static seedu.address.logic.commands.SignUpCommand.MESSAGE_SUCCESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
@@ -42,7 +43,11 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
                 .withPassword(VALID_MANAGER_PASSWORD_IDA)
                 .build();
 
-        String expectedResultMessage = String.format(MESSAGE_SUCCESS, ida);
+        String expectedResultMessage = String.format(MESSAGE_SUCCESS, ida)
+                + "\n"
+                + MESSAGE_LOGGED_IN;
+
+
         assertCommandSuccess(command, expectedModel, expectedResultMessage);
     }
 

--- a/src/test/java/systemtests/SignUpCommandSystemTest.java
+++ b/src/test/java/systemtests/SignUpCommandSystemTest.java
@@ -1,0 +1,126 @@
+package systemtests;
+
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PASSWORD_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_USERNAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_ALICE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_USERNAME_IDA;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_DUPLICATE_USER;
+import static seedu.address.logic.commands.SignUpCommand.MESSAGE_SUCCESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PASSWORD;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_USERNAME;
+import static seedu.address.model.person.Name.MESSAGE_NAME_CONSTRAINTS;
+import static seedu.address.model.person.Password.MESSAGE_PASSWORD_CONSTRAINTS;
+import static seedu.address.model.person.Username.MESSAGE_USERNAME_CONSTRAINTS;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.SignUpCommand;
+import seedu.address.model.Model;
+import seedu.address.model.user.User;
+import seedu.address.testutil.user.UserBuilder;
+
+public class SignUpCommandSystemTest extends OrderBookSystemTest {
+
+    private String signupCommand = SignUpCommand.COMMAND_WORD + " ";
+
+    @Test
+    public void signup_newUser_successful() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_IDA
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_IDA
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_IDA;
+
+        User ida = new UserBuilder()
+                .withName(VALID_MANAGER_NAME_IDA)
+                .withUsername(VALID_MANAGER_USERNAME_IDA)
+                .withPassword(VALID_MANAGER_PASSWORD_IDA)
+                .build();
+
+        String expectedResultMessage = String.format(MESSAGE_SUCCESS, ida);
+        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+    }
+
+    @Test
+    public void signup_exisitingUser_failure() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+
+        assertCommandFailure(command, MESSAGE_DUPLICATE_USER);
+    }
+
+    @Test
+    public void signup_invalidName_failure() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + INVALID_NAME_DESC
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+
+        assertCommandFailure(command, MESSAGE_NAME_CONSTRAINTS);
+    }
+
+    @Test
+    public void signup_invalidUsername_failure() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
+                + " " + PREFIX_USERNAME + INVALID_USERNAME_DESC
+                + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
+
+        assertCommandFailure(command, MESSAGE_USERNAME_CONSTRAINTS);
+    }
+
+    @Test
+    public void signup_invalidPassword_failure() {
+        Model expectedModel = getModel();
+        String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
+                + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
+                + " " + PREFIX_PASSWORD + INVALID_PASSWORD_DESC;
+
+        assertCommandFailure(command, MESSAGE_PASSWORD_CONSTRAINTS);
+    }
+
+
+    /**
+     * Executes {@code command} and verifies that the command box displays an empty string, the result display
+     * box displays {@code Messages#MESSAGE_ORDERS_LISTED_OVERVIEW} with the number of people in the filtered list,
+     * and the model related components equal to {@code expectedModel}.
+     * These verifications are done by
+     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
+     * selected card updated accordingly, depending on {@code cardStatus}.
+     *
+     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {
+        executeCommand(command);
+        assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
+        assertCommandBoxShowsDefaultStyle();
+        assertStatusBarUnchanged();
+    }
+
+    /**
+     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
+     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
+     * These verifications are done by
+     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
+     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
+     * error style.
+     *
+     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     */
+    private void assertCommandFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+
+        executeCommand(command);
+        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertCommandBoxShowsErrorStyle();
+        assertStatusBarUnchanged();
+    }
+}


### PR DESCRIPTION
In this PR,
- Update UI when user login 
- Update UI after user signup
- Prevent unauthenticated user from using all the `/order` command
- Unauthenticated user can use `/login` , `/signup` , `/help` , `/history`
- Added the necessary test for relevant classes

Fixes #31 