### PR TITLE
Fixed NAME and USERNAME length

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -45,7 +45,7 @@ public class LogicManager extends ComponentManager implements Logic {
             if (model.isUserLoggedIn() || isNotAuthenticatedCommand(command)) {
                 return command.execute(model, history);
             } else {
-                return new CommandResult(MESSAGE_REQUIRE_LOGIN);
+                throw new CommandException(MESSAGE_REQUIRE_LOGIN);
             }
         } finally {
             history.add(commandText);

--- a/src/main/java/seedu/address/logic/commands/LoginCommand.java
+++ b/src/main/java/seedu/address/logic/commands/LoginCommand.java
@@ -51,7 +51,7 @@ public class LoginCommand extends Command {
             String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser.getUsername())
                     + "\n"
                     + MESSAGE_REDIRECT_TO_LOGOUT;
-            return new CommandResult(result);
+            throw new CommandException(result);
         }
 
         if (model.isRegisteredUser(toLogin)) {

--- a/src/main/java/seedu/address/logic/commands/SignUpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SignUpCommand.java
@@ -51,7 +51,7 @@ public class SignUpCommand extends Command {
             String result = String.format(MESSAGE_ALREADY_LOGGED_IN, loggedInUser.getUsername())
                     + "\n"
                     + MESSAGE_REDIRECT_TO_LOGOUT;
-            return new CommandResult(result);
+            throw new CommandException(result);
         }
 
         if (model.hasUser(toAdd)) {

--- a/src/main/java/seedu/address/logic/commands/order/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/AddCommand.java
@@ -31,7 +31,7 @@ public class AddCommand extends OrderCommand {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_FOOD + "Roti Prata "
-            + PREFIX_FOOD + "Ice Milo"
+            + PREFIX_FOOD + "Ice Milo "
             + PREFIX_DATE + "12-10-2018 00:00:00";
 
     public static final String MESSAGE_SUCCESS = "New order added: %1$s";

--- a/src/main/java/seedu/address/model/common/Name.java
+++ b/src/main/java/seedu/address/model/common/Name.java
@@ -10,13 +10,14 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name {
 
     public static final String MESSAGE_NAME_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphanumeric characters and spaces, it should not be blank "
+                    + "and be 3 to 64 characters long.";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{3,64}";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/common/Name.java
+++ b/src/main/java/seedu/address/model/common/Name.java
@@ -17,7 +17,7 @@ public class Name {
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{3,64}";
+    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]{1,64}";
 
     public final String fullName;
 

--- a/src/main/java/seedu/address/model/common/Username.java
+++ b/src/main/java/seedu/address/model/common/Username.java
@@ -9,13 +9,14 @@ import static java.util.Objects.requireNonNull;
 public class Username {
 
     public static final String MESSAGE_USERNAME_CONSTRAINTS =
-            "Username should only contain alphanumeric characters and it should not be blank";
+            "Username should only contain alphanumeric characters, it should not be blank "
+                    + "and be 3 to 64 characters long.";
 
     /*
      * The first character of the username must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String USERNAME_VALIDATION_REGEX = "[\\p{Alnum}]+";
+    public static final String USERNAME_VALIDATION_REGEX = "[\\p{Alnum}]{3,64}";
     public final String value;
 
 

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import static org.junit.Assert.assertEquals;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX;
+import static seedu.address.commons.core.Messages.MESSAGE_REQUIRE_LOGIN;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_NAME_IDA;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_MANAGER_PASSWORD_IDA;
@@ -17,6 +18,7 @@ import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.HistoryCommand;
+import seedu.address.logic.commands.LogoutCommand;
 import seedu.address.logic.commands.SignUpCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.order.ListCommand;
@@ -70,6 +72,15 @@ public class LogicManagerTest {
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         thrown.expect(UnsupportedOperationException.class);
         logic.getFilteredOrderList().remove(0);
+    }
+
+    @Test
+    public void execute_validCommand_notLogin() {
+        String logoutCommand = LogoutCommand.COMMAND_WORD;
+        assertCommandSuccess(logoutCommand, LogoutCommand.MESSAGE_SUCCESS, model);
+
+        String listCommand = OrderCommand.COMMAND_WORD + " " + ListCommand.COMMAND_WORD;
+        assertCommandException(listCommand, MESSAGE_REQUIRE_LOGIN);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/LoginCommandTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.CommandHistory;
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -56,11 +57,12 @@ public class LoginCommandTest {
                 .withPassword(VALID_MANAGER_PASSWORD_BENSON)
                 .build();
 
-        commandResult = new LoginCommand(anotherUser).execute(model, commandHistory);
         String expectedResult = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN, validUser.getUsername())
                 + "\n"
                 + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
-        assertEquals(expectedResult, commandResult.feedbackToUser);
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(expectedResult);
+        new LoginCommand(anotherUser).execute(model, commandHistory);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SignUpCommandTest.java
@@ -62,11 +62,14 @@ public class SignUpCommandTest {
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
 
         User anotherUser = new UserBuilder(IDA_MANAGER).build();
-        commandResult = new SignUpCommand(anotherUser).execute(model, commandHistory);
+
         expectedResult = String.format(MESSAGE_ALREADY_LOGGED_IN, validUser.getUsername())
                 + "\n"
                 + MESSAGE_REDIRECT_TO_LOGOUT;
-        assertEquals(expectedResult, commandResult.feedbackToUser);
+        thrown.expect(CommandException.class);
+        thrown.expectMessage(expectedResult);
+        new SignUpCommand(anotherUser).execute(model, commandHistory);
+
         assertEquals(EMPTY_COMMAND_HISTORY, commandHistory);
 
     }

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -12,8 +12,6 @@ import javafx.scene.input.KeyCode;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
 import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.order.ListCommand;
-import seedu.address.logic.commands.order.OrderCommand;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 

--- a/src/test/java/seedu/address/ui/CommandBoxTest.java
+++ b/src/test/java/seedu/address/ui/CommandBoxTest.java
@@ -11,6 +11,7 @@ import guitests.guihandles.CommandBoxHandle;
 import javafx.scene.input.KeyCode;
 import seedu.address.logic.Logic;
 import seedu.address.logic.LogicManager;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.order.ListCommand;
 import seedu.address.logic.commands.order.OrderCommand;
 import seedu.address.model.Model;
@@ -18,7 +19,7 @@ import seedu.address.model.ModelManager;
 
 public class CommandBoxTest extends GuiUnitTest {
 
-    private static final String COMMAND_THAT_SUCCEEDS = OrderCommand.COMMAND_WORD + " " + ListCommand.COMMAND_WORD;
+    private static final String COMMAND_THAT_SUCCEEDS = HelpCommand.COMMAND_WORD;
     private static final String COMMAND_THAT_FAILS = "invalid command";
 
     private ArrayList<String> defaultStyleOfCommandBox;
@@ -92,7 +93,7 @@ public class CommandBoxTest extends GuiUnitTest {
 
         // insert command in the middle of retrieving previous commands
         guiRobot.push(KeyCode.UP);
-        String thirdCommand = "/order list";
+        String thirdCommand = "/help";
         commandBoxHandle.run(thirdCommand);
         assertInputHistory(KeyCode.UP, thirdCommand);
         assertInputHistory(KeyCode.UP, COMMAND_THAT_FAILS);

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -37,7 +37,6 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_HOON;
         expectedResultMessage = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN,
                 VALID_MANAGER_USERNAME_ALICE) + "\n" + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
-        System.out.println(expectedResultMessage);
         assertCommandLoginFailure(command, expectedResultMessage);
     }
 

--- a/src/test/java/systemtests/LoginCommandSystemTest.java
+++ b/src/test/java/systemtests/LoginCommandSystemTest.java
@@ -37,7 +37,8 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_HOON;
         expectedResultMessage = String.format(LoginCommand.MESSAGE_ALREADY_LOGGED_IN,
                 VALID_MANAGER_USERNAME_ALICE) + "\n" + LoginCommand.MESSAGE_REDIRECT_TO_LOGOUT;
-        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+        System.out.println(expectedResultMessage);
+        assertCommandLoginFailure(command, expectedResultMessage);
     }
 
     @Test
@@ -82,15 +83,7 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
 
 
     /**
-     * Executes {@code command} and verifies that the command box displays an empty string, the result display
-     * box displays {@code Messages#MESSAGE_ORDERS_LISTED_OVERVIEW} with the number of people in the filtered list,
-     * and the model related components equal to {@code expectedModel}.
-     * These verifications are done by
-     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
-     * selected card updated accordingly, depending on {@code cardStatus}.
-     *
-     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     * Assert that login command succeed with order panel showing. Command box should be empty and default style.
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {
 
@@ -102,20 +95,24 @@ public class LoginCommandSystemTest extends OrderBookSystemTest {
     }
 
     /**
-     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
-     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
-     * These verifications are done by
-     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
-     * error style.
-     *
-     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     * Assert that login command fails. Command box should be empty and default style.
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
         Model expectedModel = getModel();
         executeCommand(command);
         assertApplicationDisplaysExpected("", expectedResultMessage, expectedModel);
         assertCommandBoxShowsDefaultStyle();
+        assertStatusBarUnchanged();
+    }
+
+    /**
+     * Assert that after login, user cannot login again.
+     */
+    private void assertCommandLoginFailure(String command, String expectedResultMessage) {
+        Model expectedModel = getModel();
+        executeCommand(command);
+        assertApplicationDisplaysExpected(command, expectedResultMessage, expectedModel);
+        assertCommandBoxShowsErrorStyle();
         assertStatusBarUnchanged();
     }
 }

--- a/src/test/java/systemtests/SignUpCommandSystemTest.java
+++ b/src/test/java/systemtests/SignUpCommandSystemTest.java
@@ -68,12 +68,11 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
         expectedResultMessage = String.format(MESSAGE_ALREADY_LOGGED_IN, ida.getUsername())
                 + "\n"
                 + MESSAGE_REDIRECT_TO_LOGOUT;
-        assertCommandSuccess(command, expectedModel, expectedResultMessage);
+        assertCommandFailure(command, expectedResultMessage);
     }
 
     @Test
     public void signup_exisitingUser_failure() {
-        Model expectedModel = getModel();
         String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
                 + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
@@ -83,7 +82,6 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
 
     @Test
     public void signup_invalidName_failure() {
-        Model expectedModel = getModel();
         String command = signupCommand + PREFIX_NAME + INVALID_NAME_DESC
                 + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
@@ -93,7 +91,6 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
 
     @Test
     public void signup_invalidUsername_failure() {
-        Model expectedModel = getModel();
         String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
                 + " " + PREFIX_USERNAME + INVALID_USERNAME_DESC
                 + " " + PREFIX_PASSWORD + VALID_MANAGER_PASSWORD_ALICE;
@@ -103,7 +100,6 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
 
     @Test
     public void signup_invalidPassword_failure() {
-        Model expectedModel = getModel();
         String command = signupCommand + PREFIX_NAME + VALID_MANAGER_NAME_ALICE
                 + " " + PREFIX_USERNAME + VALID_MANAGER_USERNAME_ALICE
                 + " " + PREFIX_PASSWORD + INVALID_PASSWORD_DESC;
@@ -113,15 +109,7 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
 
 
     /**
-     * Executes {@code command} and verifies that the command box displays an empty string, the result display
-     * box displays {@code Messages#MESSAGE_ORDERS_LISTED_OVERVIEW} with the number of people in the filtered list,
-     * and the model related components equal to {@code expectedModel}.
-     * These verifications are done by
-     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the status bar remains unchanged, and the command box has the default style class, and the
-     * selected card updated accordingly, depending on {@code cardStatus}.
-     *
-     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     * Assert that signup command succeed. Command box style should be default.
      */
     private void assertCommandSuccess(String command, Model expectedModel, String expectedResultMessage) {
         executeCommand(command);
@@ -131,14 +119,7 @@ public class SignUpCommandSystemTest extends OrderBookSystemTest {
     }
 
     /**
-     * Executes {@code command} and verifies that the command box displays {@code command}, the result display
-     * box displays {@code expectedResultMessage} and the model related components equal to the current model.
-     * These verifications are done by
-     * {@code OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)}.<br>
-     * Also verifies that the browser url, selected card and status bar remain unchanged, and the command box has the
-     * error style.
-     *
-     * @see OrderBookSystemTest#assertApplicationDisplaysExpected(String, String, Model)
+     * Assert that signup command fails. Command box style should change.
      */
     private void assertCommandFailure(String command, String expectedResultMessage) {
         Model expectedModel = getModel();


### PR DESCRIPTION
In this PR
- `NAME` now has to be between 1 to 64 char
- `USERNAME` now has to be between 3 to 64 char
- `/order add` example typo fixed. 
- used `CommandException` instead of `CommandResult` inside `login`,`signup` and `logicmanager`
- Update relevant test