### PR TITLE
Update UG and DG on /route and /assign

### DIFF
--- a/docs/DeveloperGuide.adoc
+++ b/docs/DeveloperGuide.adoc
@@ -524,11 +524,14 @@ a `ParseException` would be thrown.
 ** Pros: Allows for greater flexibility in how deliverymen interact with other resources like order/routes - better separation of concerns.
 ** Cons: Harder to implement & maintain
 
-* **Alternative 2:** Deliverymen are stored in the same file as `Order` s
+* **Alternative 2:** Deliverymen are stored in the same file as `Order`
 ** Pros: Easier to implement & maintain
 ** Cons: Deliveryman can only be accessed & treated as parts of an `Order`
 
-=== Create Route Feature
+=== Create Route Feature [deprecated since v1.2.1]
+This feature is deprecated as there was a design change regarding the relationship between delivery man and order.
+Previously, route was the middleman between delivery men and orders. Now, delivery men and orders are directly related.
+Route is removed as its existence will complicate implementations of other features without adding much benefit.
 
 ==== Current Implementation
 The `create` route command allows creation of routes in FoodZoom.

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -251,7 +251,7 @@ Deletes the 1st delivery man in the results of the `find` command.
 Clears all entries from the list of delivery men. +
 Format: `/deliveryman clear`
 
-=== Creating a new route: `/route create` `[Since v1.1]`
+=== Creating a new route: `/route create` `[Deprecated since v1.2.1]`
 
 Creates a route with a set of orders +
 Format: `/route create o/ORDER_ID`
@@ -265,65 +265,26 @@ Examples:
 
 * `/route create o/1 o/3`
 
-=== Listing all available routes: `/route list` `[Coming in v2.0]`
+=== Assign route to delivery man : `/assign` `[Since v1.3]`
 
-Shows a list of all existing routes and assigned delivery men +
-Format: `/route list`
-
-=== Adding an order to a route : `/route add` `[Coming in v2.0]`
-
-Add an existing order to an existing route +
-Format: `/route add r/ROUTE_INDEX o/ORDER_INDEX`
+Assign multiple orders to a delivery man +
+Format: `/assign d/DELIVERYMAN_INDEX o/ORDER_INDEX`
 
 ****
-* All fields need to have at least a value. e.g. `o/` is not allowed.
-* Able to add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
-****
-
-Examples:
-
-* `/route list` +
-`/order list` +
-`/route add r/1 o/2` +
-Adds the 2nd order to the 1st route.
-* `/route list` +
-`/order list` +
-`/route add r/3 o/4 o/5 o/6` +
-Adds the 4th, 5th, 6th order to the 3rd route.
-
-=== Deleting a route: `/route delete` `[Coming in v2.0]`
-
-Deletes the specified route from the list of routes +
-Format: `/route delete INDEX`
-
-****
-* Deletes a route at the specified `INDEX`.
-* The index refers to the index number shown by `/route list`.
-* The index *must be a positive integer* 1, 2, 3, ...
+* Assigns orders at the specific `ORDER_INDEX` to the delivery man at the `DELIVERYMAN_INDEX`
+* The index refers to the index number shown in the displayed delivery men list or orders list respectively.
+* The index *must be a positive integer* 1, 2, 3, ... and must be within the number of displayed delivery men or orders
+respectively.
+* There must be at least 1 order and 1 delivery man.
+* Add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
 ****
 
 Examples:
 
-* `/route list` +
-`/route delete 2` +
-Deletes the 2nd route in the list of routes.
-
-=== Clearing all routes : `/route clear` `[Coming in v2.0]`
-
-Clears all entries from the list of routes. +
-Format: `/route clear`
-
-=== Assign route to delivery man : `/assign` `[Coming in v2.0]`
-
-Assign a delivery man to an existing route +
-Format: `/assign d/DELIVERYMAN_INDEX r/ROUTE_INDEX`
-
-Examples:
-
-* `/route list` +
+* `/order list` +
 `/deliveryman list` +
-`/assign d/2 r/1` +
-Add the 2nd delivery man to the 1st route.
+`/assign d/2 o/1 o/2` +
+Assigns order number 1 and 2 to delivery man number 2.
 
 === Listing entered commands : `/history` `[Since v1.1]`
 
@@ -367,11 +328,6 @@ Examples:
 
 Format: `/logout`
 
-=== Show delivery route : `/route list` `(Deliveryman Command)` `[Coming in v2.0]`
-
-View the assigned route/s +
-Format: `/route list`
-
 === Listing assigned orders : `/order list` `(Deliveryman Command)` `[Coming in v2.0]`
 
 List details of assigned order/s +
@@ -414,16 +370,10 @@ e.g. `/deliveryman find n/James Jake`
 * *Delete delivery man* : `/deliveryman delete INDEX` +
 e.g. `/deliveryman delete 3`
 * *Clear delivery men* : `/deliveryman clear`
-* *Create a route* : `/route create o/ORDER_ID` +
+* *Create a route* : `/route create o/ORDER_ID` *[DEPRECATED]* +
 e.g. `/route create o/1 o/3`
-* *Listing all routes* : `/route list`
-* *Add order to route* : `/route add r/ROUTE_INDEX o/ORDER_INDEX` +
-e.g. `/route add o/1 o/2 o/3 r/1`
-* *Delete a route* : `/route delete INDEX` +
-e.g. `/route delete 1`
-* *Clear routes* : `/route clear`
-* *Assign route to delivery man* : `/assign d/DELIVERYMAN_INDEX r/ROUTE_INDEX` +
-e.g. `/assign d/1 r/1`
+* *Assign route to delivery man* : `/assign d/DELIVERYMAN_INDEX o/ORDER_INDEX` +
+e.g. `/assign d/1 o/1`
 * *Help* : `/help`
 * *History* : `/history`
 * *Exit the program* : `/exit`


### PR DESCRIPTION
- /route create command is deprecated
- other /route commands are removed from UG
- update DG on Create Route feature and why it is deprecated