### PR TITLE
Fixes order and deliveryman find command issues and fix commands examples

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -49,13 +49,13 @@ the format to be used for all the commands and the syntax that is to be followed
 ====
 *Command Format*
 
-* Words in `UPPER_CASE` are the parameters to be supplied by the user e.g. in `add n/NAME`, `NAME` is a parameter which can be used as `add n/John Doe`.
+* Words in `UPPER_CASE` are the parameters to be supplied by the user e.g. in `/order add n/NAME`, `NAME` is a parameter which can be used as `/order add n/John Doe`.
 * Items in square brackets are optional e.g `n/NAME [p/PHONE]` can be used as `n/John Doe p/9112` or as `n/John Doe`.
 * Parameters can be in any order e.g. if the command specifies `n/NAME a/ADDRESS`, `a/ADDRESS n/NAME` is also acceptable.
 ====
 
 ====
-*Fields restrictions*:
+*Fields restrictions*
 [width="100%",cols="20%,<80%"]
 |=======================================================================
 
@@ -69,6 +69,8 @@ the format to be used for all the commands and the syntax that is to be followed
 
 |DATETIME | Must conform to the format `dd-MM-YYYY h:m:s`, where _dd_ is date, _MM_ is month, _YYYY_ is year, _h_ is 24 hour of the day, _m_ is minutes and _s_ is seconds. e.g. `14-10-2018 23:30:00`
 
+|ORDER_STATUS | Only `PENDING`, `ONGOING` or `COMPLETED` are allowed
+
 |USERNAME | Can be alphanumeric and spaces are *NOT* allowed, it should not be blank and be 3 to 64 characters long.
 
 |PASSWORD | Can be alphanumeric, should be at least *6* characters long and spaces are *NOT* allowed. Not encrypted
@@ -80,7 +82,7 @@ in current releases.
 ====
 
 ====
-*Available Commands*:
+*Available Commands*
 [cols="s,a"]
 |=======================================================================
 
@@ -106,15 +108,21 @@ in current releases.
 
 `/order find`
 
+`/order select`
+
 `/order delete`
 
 `/order clear`
+
+`/order done`
 
 `/deliveryman add`
 
 `/deliveryman list`
 
 `/deliveryman find`
+
+`/deliveryman select`
 
 `/deliveryman delete`
 
@@ -183,7 +191,7 @@ Format: `/order add f/FOOD n/NAME p/PHONE a/ADDRESS dt/DATETIME`
 ****
 * Able to add more than 1 food items by specifying more food tags. e.g. `f/Roti Prata f/Ice Milo`.
 * Address must be a valid address that exists in Singapore to be displayed on the map.
-* If the postal code is longer than 6 digits, much like any other field, only the last 6 digits will be taken into
+* If the postal code is longer than 6 digits, much like any other field, only the *last 6 digits* will be taken into
 consideration
 * The manager is able to add dates from any time period as long as it is valid.
 * Two orders are considered the same if they have the same name, phone, and date time.
@@ -227,17 +235,17 @@ Edits the food of the 2nd order to be `Maggi Goreng, Ice Milo`.
 === Finding orders : `/order find` `[Since v1.2]`
 
 Find any order/s with any given order fields. +
-Format: `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME]` +
+Format: `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st\ORDER_STATUS]` +
 
 ****
 * All fields are optional. However, at least one field must be specified.
 * Empty value after any fields are not allowed. e.g. `n/`
 * The search is case insensitive. e.g `tom` will match `Tom`
-* Partial match is allowed for name, phone and food. e.g. `alex` will match `alex lim`
-* To find for orders with a date range, use 2 date fields. e.g. `dt/01-10-2018 10:00:00 dt/03-10-2018
-  10:00:00` will return order/s within the 2 dates.
+* Partial match is allowed for name, phone and food. e.g. `alex` will match `alex lim` and `al` will match `alex lim`
 * To find for orders from a specific date, use 1 date field. e.g `dt/01-10-2018 10:00:00` will return order/s on that
  date.
+* To find for orders with a date range, use 2 date fields. e.g. `dt/01-10-2018 10:00:00 dt/03-10-2018
+  10:00:00` will return order/s within the 2 dates.
 ****
 
 Examples:
@@ -315,7 +323,7 @@ Format: `/deliveryman list`
 === Editing a delivery man : `/deliveryman edit` `[Coming in v2.0]`
 
 Edits an existing delivery man in the list of delivery men. +
-Format: `/delivery man edit INDEX n/NAME`
+Format: `/deliveryman edit INDEX n/NAME`
 
 ****
 * Edits the delivery man at the specified `INDEX`.
@@ -390,22 +398,6 @@ Selects the 1st deliveryman in the results of the `find` command.
 Clears all entries from the list of delivery men. +
 Format: `/deliveryman clear`
 
-// tag::routecreatefeature[]
-=== Creating a new route: `/route create` `[Deprecated since v1.2.1]`
-
-Creates a route with a set of orders +
-Format: `/route create o/ORDER_ID`
-
-****
-* All fields need to have at least a value. e.g. `o/` is not allowed.
-* Able to add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
-****
-
-Examples:
-
-* `/route create o/1 o/3`
-// end::routecreatefeature[]
-
 // tag::assignfeature[]
 === Assign orders to a delivery man : `/assign` `[Since v1.3]`
 
@@ -414,9 +406,6 @@ Format: `/assign d/DELIVERYMAN_INDEX o/ORDER_INDEX`
 
 ****
 * Assigns orders at the specific `ORDER_INDEX` to the delivery man at the `DELIVERYMAN_INDEX`
-* The index refers to the index number shown in the displayed delivery men list or orders list respectively.
-* The index *must be a positive integer* 1, 2, 3, ... and must be within the number of displayed delivery men or orders
-respectively.
 * There must be at least 1 order and 1 delivery man.
 * Add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
 * Orders that are already assigned to a deliveryman cannot be reassigned.
@@ -444,6 +433,22 @@ Pressing the kbd:[&uarr;] and kbd:[&darr;] arrows will display the previous and 
 
 Exits the program. +
 Format: `/exit`
+
+// tag::routecreatefeature[]
+=== Creating a new route: `/route create` `[Deprecated since v1.2.1]`
+
+Creates a route with a set of orders +
+Format: `/route create o/ORDER_ID`
+
+****
+* All fields need to have at least a value. e.g. `o/` is not allowed.
+* Able to add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
+****
+
+Examples:
+
+* `/route create o/1 o/3`
+// end::routecreatefeature[]
 
 === Saving the data
 
@@ -489,12 +494,12 @@ e.g. `/signup n/John Doe u/johndoe pw/johndoepassword`
 e.g. `/login u/manager pw/password`
 * *Logout* : `/logout`
 * *Return to Home* : `/home`
-* *Add order* : `/order add f/FOOD n/NAME p/PHONE_NUMBER a/ADDRESS dt/DATETIME` +
+* *Add order* : `/order add f/FOOD n/NAME p/PHONE a/ADDRESS dt/DATETIME` +
 e.g. `/order add f/Roti Prata n/James Ho p/22224444 a/block 123, Clementi Rd, 1234665 dt/14-12-2018 10:18:00`
 * *Listing orders* : `/order list`
-* *Edit order* : `/order edit INDEX [f/FOOD] [n/NAME] [p/PHONE_NUMBER] [a/ADDRESS] [dt/DATETIME]` +
+* *Edit order* : `/order edit INDEX [f/FOOD] [n/NAME] [p/PHONE] [a/ADDRESS] [dt/DATETIME]` +
 e.g. `/order edit 2 n/James Lee`
-* *Find order* : `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME]` +
+* *Find order* : `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st\ORDER_STATUS]` +
 e.g. `/order find n/James Jake`
 * *Delete order* : `/order delete INDEX` +
 e.g. `/order delete 3`
@@ -510,14 +515,16 @@ e.g. `/deliveryman edit 2 n/James Lee`
 e.g. `/deliveryman find n/James Jake`
 * *Delete delivery man* : `/deliveryman delete INDEX` +
 e.g. `/deliveryman delete 3`
+* *Select delivery man* : `/deliveryman select INDEX` +
+e.g. `/deliveryman select 1`
 * *Clear delivery men* (Coming in v2.0) : `/deliveryman clear`
-* *Create a route* [DEPRECATED] : `/route create o/ORDER_INDEX` +
-e.g. `/route create o/1 o/3`
 * *Assign orders to a delivery man* : `/assign d/DELIVERYMAN_INDEX o/ORDER_INDEX` +
 e.g. `/assign d/1 o/1 o/3`
 * *Help* : `/help`
 * *History* : `/history`
 * *Exit the program* : `/exit`
+* *Create a route* [DEPRECATED] : `/route create o/ORDER_INDEX` +
+e.g. `/route create o/1 o/3`
 
 * *Login (Deliveryman)* (Coming in v2.0) : `/login u/USERNAME pw/PASSWORD` +
 e.g. `/login u/deliveryman pw/password`

--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -235,7 +235,7 @@ Edits the food of the 2nd order to be `Maggi Goreng, Ice Milo`.
 === Finding orders : `/order find` `[Since v1.2]`
 
 Find any order/s with any given order fields. +
-Format: `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st\ORDER_STATUS]` +
+Format: `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st/ORDER_STATUS]` +
 
 ****
 * All fields are optional. However, at least one field must be specified.
@@ -499,7 +499,7 @@ e.g. `/order add f/Roti Prata n/James Ho p/22224444 a/block 123, Clementi Rd, 12
 * *Listing orders* : `/order list`
 * *Edit order* : `/order edit INDEX [f/FOOD] [n/NAME] [p/PHONE] [a/ADDRESS] [dt/DATETIME]` +
 e.g. `/order edit 2 n/James Lee`
-* *Find order* : `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st\ORDER_STATUS]` +
+* *Find order* : `/order find [n/NAME] [p/PHONE] [a/ADDRESS] [f/FOOD] [dt/DATETIME] [st/ORDER_STATUS]` +
 e.g. `/order find n/James Jake`
 * *Delete order* : `/order delete INDEX` +
 e.g. `/order delete 3`

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -28,15 +28,15 @@ public class StringUtil {
         requireNonNull(sentence);
         requireNonNull(word);
 
-        String preppedWord = word.trim();
+        String preppedWord = word.trim().toLowerCase();
         checkArgument(!preppedWord.isEmpty(), "Word parameter cannot be empty");
         checkArgument(preppedWord.split("\\s+").length == 1, "Word parameter should be a single word");
 
-        String preppedSentence = sentence;
+        String preppedSentence = sentence.toLowerCase();
         String[] wordsInPreppedSentence = preppedSentence.split("\\s+");
 
         return Arrays.stream(wordsInPreppedSentence)
-                .anyMatch(preppedWord::equalsIgnoreCase);
+                .anyMatch(wordInPreppedSentence -> wordInPreppedSentence.contains(preppedWord));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanAddCommand.java
@@ -16,10 +16,11 @@ public class DeliverymanAddCommand extends DeliverymanCommand {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds deliveryman to the list. "
+    public static final String MESSAGE_USAGE = DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + ": Adds deliveryman to the list. \n"
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
-            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "NAME \n"
+            + "Example: " + DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD + " "
             + PREFIX_NAME + "Lorem Ipsum";
 
     public static final String MESSAGE_SUCCESS = "New deliveryman added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanDeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanDeleteCommand.java
@@ -19,10 +19,10 @@ public class DeliverymanDeleteCommand extends DeliverymanCommand {
 
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes the deliveryman identified by the index number used in the displayed deliveryman list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_DELIVERYMAN_SUCCESS = "Deleted Deliveryman: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanFindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanFindCommand.java
@@ -16,11 +16,11 @@ import seedu.address.model.deliveryman.DeliverymanNameContainsKeywordsPredicate;
 public class DeliverymanFindCommand extends DeliverymanCommand {
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Finds the deliveryman whose name contains any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: n/KEYWORD \n"
-            + "Example: " + COMMAND_WORD + " n/Alex";
+            + "Example: " + DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD + " n/Alex";
 
     private final DeliverymanNameContainsKeywordsPredicate predicate;
 

--- a/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanSelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/deliveryman/DeliverymanSelectCommand.java
@@ -20,8 +20,8 @@ import seedu.address.model.deliveryman.Deliveryman;
 public class DeliverymanSelectCommand extends DeliverymanCommand {
     public static final String COMMAND_WORD = "select";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Selects the order identified by the index number used in the displayed order list.\n"
+    public static final String MESSAGE_USAGE = DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD
+        + ": Selects the deliveryman identified by the index number used in the displayed deliveryman list.\n"
         + "Parameters: INDEX (must be a positive integer)\n"
         + "Example: " + DeliverymanCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/order/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/AddCommand.java
@@ -20,11 +20,13 @@ public class AddCommand extends OrderCommand {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an order to the order book. "
+    public static final String MESSAGE_USAGE = OrderCommand.COMMAND_WORD + " " + COMMAND_WORD
+            + ": Adds an order to the order book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_DATE + "DATETIME "
             + PREFIX_FOOD + "FOOD...\n"
             + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "

--- a/src/main/java/seedu/address/logic/commands/order/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/DeleteCommand.java
@@ -19,7 +19,7 @@ public class DeleteCommand extends OrderCommand {
 
     public static final String COMMAND_WORD = "delete";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = OrderCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Deletes the order identified by the index number used in the displayed order list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1";

--- a/src/main/java/seedu/address/logic/commands/order/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/EditCommand.java
@@ -48,7 +48,7 @@ public class EditCommand extends OrderCommand {
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_DATE + "DATE] "
             + "[" + PREFIX_FOOD + "FOOD]...\n"
-            + "Example: " + OrderCommand.COMMAND_WORD + COMMAND_WORD + " 1 "
+            + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_FOOD + "Roti Prata "
             + PREFIX_FOOD + "Ice Milo";

--- a/src/main/java/seedu/address/logic/commands/order/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/FindCommand.java
@@ -19,10 +19,10 @@ import seedu.address.model.order.Order;
 public class FindCommand extends OrderCommand {
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = OrderCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Finds the order whose keywords contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: [n/NAME] [p/PHONE] [a/ADDRESS] [dt/DATETIME] [f/FOOD]\n"
+            + "Parameters: [n/NAME] [p/PHONE] [a/ADDRESS] [dt/DATETIME] [f/FOOD] [st/ORDER_STATUS]\n"
             + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD + " n/John f/Ice Milo\n"
             + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD
             + " dt/01-10-2018 10:00:00 dt/03-10-2018 10:00:00";

--- a/src/main/java/seedu/address/logic/commands/order/SelectCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/SelectCommand.java
@@ -21,7 +21,7 @@ public class SelectCommand extends OrderCommand {
 
     public static final String COMMAND_WORD = "select";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = OrderCommand.COMMAND_WORD + " " + COMMAND_WORD
             + ": Selects the order identified by the index number used in the displayed order list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + OrderCommand.COMMAND_WORD + " " + COMMAND_WORD + " 1";

--- a/src/main/java/seedu/address/logic/parser/deliveryman/DeliverymanFindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/deliveryman/DeliverymanFindCommandParser.java
@@ -21,6 +21,8 @@ import seedu.address.model.deliveryman.DeliverymanNameContainsKeywordsPredicate;
  * @throws ParseException if the user input does not conform the expected format
  */
 public class DeliverymanFindCommandParser implements Parser<DeliverymanCommand> {
+    public static final String MESSAGE_EMPTY_NAME_FIELD = "n/ cannot be empty";
+
     /**
      * Parses the given {@code String} of arguments in the context of the DeliverymanFindCommand
      * and returns an DeliverymanFindCommand object for execution.
@@ -38,6 +40,11 @@ public class DeliverymanFindCommandParser implements Parser<DeliverymanCommand> 
         }
 
         String name = argMultimap.getValue(PREFIX_NAME).get().trim();
+
+        if (isEmptyField(name)) {
+            throw new ParseException(MESSAGE_EMPTY_NAME_FIELD);
+        }
+
         String[] nameKeywords = name.split("\\s+");
 
         return new DeliverymanFindCommand(new DeliverymanNameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
@@ -49,5 +56,9 @@ public class DeliverymanFindCommandParser implements Parser<DeliverymanCommand> 
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    private static boolean isEmptyField(String field) {
+        return field.equals("");
     }
 }

--- a/src/main/java/seedu/address/logic/parser/order/OrderDatePredicateUtil.java
+++ b/src/main/java/seedu/address/logic/parser/order/OrderDatePredicateUtil.java
@@ -49,6 +49,7 @@ public class OrderDatePredicateUtil {
 
         for (String stringDate : stringsDates) {
             try {
+                sf.setLenient(false);
                 dates.add(sf.parse(stringDate));
             } catch (java.text.ParseException pE) {
                 throw new ParseException(OrderDate.MESSAGE_DATE_CONSTRAINTS);

--- a/src/main/java/seedu/address/logic/parser/order/OrderPredicateUtil.java
+++ b/src/main/java/seedu/address/logic/parser/order/OrderPredicateUtil.java
@@ -22,13 +22,13 @@ import seedu.address.model.order.OrderPhoneContainsKeywordPredicate;
  * Util to parse order's predicate
  */
 public class OrderPredicateUtil {
+    public static final String MESSAGE_EMPTY_KEYWORD = "%1$s cannot be empty";
+
     private static final String STRING_PREFIX_NAME = "n/";
     private static final String STRING_PREFIX_PHONE = "p/";
     private static final String STRING_PREFIX_ADDRESS = "a/";
     private static final String STRING_PREFIX_DATE = "dt/";
     private static final String STRING_PREFIX_FOOD = "f/";
-
-    private static final String MESSAGE_EMPTY_KEYWORD = "%1$s cannot be empty";
 
     private Predicate<Order> chainedPredicated;
 

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -123,7 +123,7 @@ public class StringUtilTest {
         assertFalse(StringUtil.containsWordIgnoreCase("    ", "123"));
 
         // Matches a partial word only
-        assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
+        assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bb")); // Sentence word bigger than query word
         assertFalse(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "bbbb")); // Query word bigger than sentence word
 
         // Matches word in the sentence, different upper/lower case letters
@@ -132,6 +132,9 @@ public class StringUtilTest {
         assertTrue(StringUtil.containsWordIgnoreCase("  AAA   bBb   ccc  ", "aaa")); // Sentence has extra spaces
         assertTrue(StringUtil.containsWordIgnoreCase("Aaa", "aaa")); // Only one word in sentence (boundary case)
         assertTrue(StringUtil.containsWordIgnoreCase("aaa bbb ccc", "  ccc  ")); // Leading/trailing spaces
+
+        // Matches a partial word in sentence, ignores case
+        assertTrue(StringUtil.containsWordIgnoreCase("aAaaA bBbb", "aAA")); // Partial
 
         // Matches multiple words in sentence
         assertTrue(StringUtil.containsWordIgnoreCase("AAA bBb ccc  bbb", "bbB"));

--- a/src/test/java/seedu/address/logic/parser/deliveryman/DeliverymanFindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/deliveryman/DeliverymanFindCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser.deliveryman;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.deliveryman.DeliverymanFindCommandParser.MESSAGE_EMPTY_NAME_FIELD;
 
 import java.util.Arrays;
 
@@ -21,6 +22,12 @@ public class DeliverymanFindCommandParserTest {
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliverymanFindCommand.MESSAGE_USAGE));
         assertParseFailure(parser, "find ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeliverymanFindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_emptyArgValues_throwsParseException() {
+        assertParseFailure(parser, " n/",
+                String.format(MESSAGE_EMPTY_NAME_FIELD));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/order/OrderDatePredicateUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/order/OrderDatePredicateUtilTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser.order;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -7,23 +8,22 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.junit.Rule;
 import org.junit.Test;
 
-import org.junit.rules.ExpectedException;
-
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.order.OrderDate;
 
 public class OrderDatePredicateUtilTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void test_invalidDateGiven_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
-
         List<String> invalidDates = Collections.singletonList("first");
-        List<Date> dates = new OrderDatePredicateUtil().parseDateKeywords(invalidDates);
+        assertParseFailure(invalidDates, OrderDate.MESSAGE_DATE_CONSTRAINTS);
+
+        invalidDates = Collections.singletonList("57-10-1908 00:00:00");
+        assertParseFailure(invalidDates, OrderDate.MESSAGE_DATE_CONSTRAINTS);
+
+        invalidDates = Collections.singletonList("01-15-1908 00:00:00");
+        assertParseFailure(invalidDates, OrderDate.MESSAGE_DATE_CONSTRAINTS);
     }
 
     @Test
@@ -53,5 +53,18 @@ public class OrderDatePredicateUtilTest {
         }
 
         return true;
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} is unsuccessful and the error message
+     * equals to {@code expectedMessage}.
+     */
+    private void assertParseFailure(List<String> userInput, String expectedMessage) {
+        try {
+            List<Date> dates = new OrderDatePredicateUtil().parseDateKeywords(userInput);
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(expectedMessage, pe.getMessage());
+        }
     }
 }

--- a/src/test/java/seedu/address/logic/parser/order/OrderPredicateUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/order/OrderPredicateUtilTest.java
@@ -11,9 +11,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
@@ -22,63 +20,41 @@ import seedu.address.model.order.Order;
 import seedu.address.model.order.OrderNameContainsKeywordPredicate;
 
 public class OrderPredicateUtilTest {
-    @Rule
-    public final ExpectedException thrown = ExpectedException.none();
-
     @Test
-    public void test_emptyNameTag_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
-
-        ArgumentMultimap emptyName = tokenizeInput(" n/");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyName);
+    public void test_emptyTags_throwsParseException() throws ParseException {
+        assertParseFailure(" n/", OrderPredicateUtil.MESSAGE_EMPTY_KEYWORD);
+        assertParseFailure(" p/", OrderPredicateUtil.MESSAGE_EMPTY_KEYWORD);
+        assertParseFailure(" a/", OrderPredicateUtil.MESSAGE_EMPTY_KEYWORD);
+        assertParseFailure(" dt/", OrderPredicateUtil.MESSAGE_EMPTY_KEYWORD);
+        assertParseFailure(" f/", OrderPredicateUtil.MESSAGE_EMPTY_KEYWORD);
     }
 
     @Test
-    public void test_emptyPhoneTag_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
+    public void test_singleValidPredicate_returnsTrue() throws ParseException {
+        List<String> name = Collections.singletonList("alex");
+        Predicate<Order> expectedPredicate = new OrderNameContainsKeywordPredicate(name);
 
-        ArgumentMultimap emptyPhone = tokenizeInput(" p/");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyPhone);
-    }
-
-    @Test
-    public void test_emptyAddressTag_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
-
-        ArgumentMultimap emptyAddress = tokenizeInput(" a/");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyAddress);
-    }
-
-    @Test
-    public void test_emptyDateTag_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
-
-        ArgumentMultimap emptyDate = tokenizeInput(" dt/");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyDate);
-    }
-
-    @Test
-    public void test_emptyFoodTag_throwsParseException() throws ParseException {
-        thrown.expect(ParseException.class);
-
-        ArgumentMultimap emptyFood = tokenizeInput(" f/");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyFood);
-    }
-
-    @Test
-    public void test_singlePredicate() throws ParseException {
-        Predicate<Order> expectedPredicate;
-
-        ArgumentMultimap emptyName = tokenizeInput(" n/alex");
-        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyName);
-
-        List<String> names = Collections.singletonList("alex");
-        expectedPredicate = new OrderNameContainsKeywordPredicate(names);
+        ArgumentMultimap argMultimap = tokenizeInput(" n/alex");
+        Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(argMultimap);
 
         assertEquals(predicate, expectedPredicate);
     }
 
     private ArgumentMultimap tokenizeInput(String input) {
         return ArgumentTokenizer.tokenize(input, PREFIX_NAME, PREFIX_PHONE, PREFIX_ADDRESS, PREFIX_DATE, PREFIX_FOOD);
+    }
+
+    /**
+     * Asserts that the parsing of {@code userInput} is unsuccessful and the error message
+     * equals to {@code expectedMessage}.
+     */
+    private void assertParseFailure(String userInput, String expectedMessage) {
+        try {
+            ArgumentMultimap emptyField = tokenizeInput(userInput);
+            Predicate<Order> predicate = new OrderPredicateUtil().parsePredicate(emptyField);
+            throw new AssertionError("The expected ParseException was not thrown.");
+        } catch (ParseException pe) {
+            assertEquals(String.format(expectedMessage, userInput.trim()), pe.getMessage());
+        }
     }
 }

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -146,7 +146,6 @@ public class FindCommandSystemTest extends OrderBookSystemTest {
 
         /* Case: find name in order book, keyword is substring of name -> 0 orders found */
         command = findCommand + " " + PREFIX_NAME + "Mei";
-        ModelHelper.setFilteredList(expectedModel);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
@@ -161,15 +160,16 @@ public class FindCommandSystemTest extends OrderBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find address of order in order book -> 1 order found */
-        command = findCommand + " " + PREFIX_ADDRESS + DANIEL.getAddress().value;
-        ModelHelper.setFilteredList(expectedModel, DANIEL);
+        /* Case: find food of order in order book -> 2 orders found */
+        List<Food> food = new ArrayList<>(DANIEL.getFood());
+        command = findCommand + " " + PREFIX_FOOD + food.get(0).foodName;
+        ModelHelper.setFilteredList(expectedModel, DANIEL, FIONA);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find food of order in order book -> 1 order found */
-        List<Food> food = new ArrayList<>(DANIEL.getFood());
-        command = findCommand + " " + PREFIX_FOOD + food.get(0).foodName;
+        /* Case: find address of order in order book -> 1 order found */
+        command = findCommand + " " + PREFIX_ADDRESS + DANIEL.getAddress().value;
+        ModelHelper.setFilteredList(expectedModel, DANIEL);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 


### PR DESCRIPTION
Updated: 
- Deliveryman find command and order find command to do partial string match
- To throws `ParseException` when invalid date is given on order find command `dt/51-10-2019`
- To throws `ParseException` when empty fields are given for deliveryman find command. E.g. `n/`
- Update commands example
- Update UserGuide
     - https://github.com/jinyingtan/main/blob/Issues-PEDRY/docs/UserGuide.adoc

Fixes: #134  
Fixes: #143 
Fixes: #150 