### PR TITLE
Limit size of placeholder

### DIFF
--- a/src/main/java/seedu/address/ui/MapPanel.java
+++ b/src/main/java/seedu/address/ui/MapPanel.java
@@ -49,6 +49,12 @@ public class MapPanel extends UiPart<Region> {
                 placeholderContainer = new ImageView(placeholder);
 
                 int count = orderMap.get(postalCodeKey);
+
+                // set a limit on count
+                if (count > 25) {
+                    count = 25;
+                }
+
                 int increment = 16 + count * 2;
 
                 placeholderContainer.setPreserveRatio(true);


### PR DESCRIPTION
Fixes #184 

Now, there is a limit imposed on the size of the placeholder. This will prevent the placeholder from covering the entire map if there are many orders to a specific location.

Max size:
<img width="645" alt="screen shot 2018-11-11 at 8 01 03 pm" src="https://user-images.githubusercontent.com/10579415/48312667-4c9a7180-e5ed-11e8-8127-eded173d0aa2.png">
