### PR TITLE
Fix wrong messages shown on edit, assign completed order and allow clear order if no ongoing orders

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -224,7 +224,7 @@ Format: `/order edit INDEX [f/FOOD] [n/NAME] [p/PHONE] [a/ADDRESS] [dt/DATETIME]
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * When a parameter is specified, e.g. `f/`, `n/`, empty fields are not allowed. Value must be specified.
-* Orders that are already assigned to a deliveryman cannot be edited.
+* Orders that are `Ongoing` or `Completed` cannot be edited.
 ****
 
 Examples:
@@ -272,7 +272,7 @@ Format: `/order delete INDEX`
 
 ****
 * Deletes an order at the specified `INDEX`.
-* Orders that are already assigned to a deliveryman cannot be deleted.
+* Orders that are `Ongoing` cannot be deleted.
 ****
 
 Examples:
@@ -422,7 +422,7 @@ Format: `/assign d/DELIVERYMAN_INDEX o/ORDER_INDEX`
 * Assigns orders at the specific `ORDER_INDEX` to the delivery man at the `DELIVERYMAN_INDEX`
 * There must be at least 1 order and 1 delivery man.
 * Add more than 1 orders by specifying more tags. e.g. `o/1 o/2 o/3`.
-* Orders that are already assigned to a deliveryman cannot be reassigned.
+* Orders that are `Ongoing` or `Completed` cannot be reassigned.
 ****
 
 Examples:

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -12,6 +12,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_ORDER_DISPLAYED_INDEX = "The order index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_ORDERS_LISTED_OVERVIEW = "%1$d orders listed!";
+    public static final String MESSAGE_COMPLETED_ORDER = "This order is already delivered to the customer.";
     public static final String MESSAGE_INVALID_DELIVERYMAN_DISPLAYED_INDEX =
         "The deliveryman index provided is invalid";
     public static final String MESSAGE_INVALID_DELIVERYMAN_COMMAND_FORMAT =
@@ -23,8 +24,8 @@ public class Messages {
             + "already assigned to a deliveryman.";
     public static final String MESSAGE_ORDER_ALREADY_ASSIGNED_TO_DELIVERYMAN = "Order %1$s is already assigned to "
             + "deliveryman %2$s, cannot be edited or reassigned to another deliveryman!";
-    public static final String MESSAGE_ORDER_ALREADY_ASSIGNED_TO_DELIVERYMAN_CANNOT_CLEAR = "There is an order already "
-            + "assigned to a deliveryman, order list cannot be cleared.";
+    public static final String MESSAGE_ORDER_ONGOING_CANNOT_CLEAR = "There is at least one ongoing order in the list, "
+            + "order list cannot be cleared.";
     public static final String MESSAGE_REQUIRE_LOGIN = "Please login first!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/AssignCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AssignCommand.java
@@ -64,6 +64,10 @@ public class AssignCommand extends Command {
                 throw new CommandException(Messages.MESSAGE_INVALID_ORDER_DISPLAYED_INDEX);
             }
             Order order = lastShownOrderList.get(i.getZeroBased());
+            if (order.isCompleted()) {
+                throw new CommandException(Messages.MESSAGE_COMPLETED_ORDER);
+            }
+
             if (order.isAlreadyAssignedDeliveryman()) {
                 throw new CommandException(String.format(Messages.MESSAGE_ORDER_ALREADY_ASSIGNED_TO_DELIVERYMAN,
                         i.getOneBased(), order.getDeliveryman()));

--- a/src/main/java/seedu/address/logic/commands/order/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/ClearCommand.java
@@ -23,8 +23,8 @@ public class ClearCommand extends OrderCommand {
     public CommandResult execute(Model model, CommandHistory history) throws CommandException {
         requireNonNull(model);
         for (Order order : model.getOrderBook().getOrderList()) {
-            if (order.isAlreadyAssignedDeliveryman()) {
-                throw new CommandException(Messages.MESSAGE_ORDER_ALREADY_ASSIGNED_TO_DELIVERYMAN_CANNOT_CLEAR);
+            if (order.isOngoing()) {
+                throw new CommandException(Messages.MESSAGE_ORDER_ONGOING_CANNOT_CLEAR);
             }
         }
         model.resetData(new OrderBook());

--- a/src/main/java/seedu/address/logic/commands/order/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/DeleteCommand.java
@@ -42,7 +42,7 @@ public class DeleteCommand extends OrderCommand {
         }
 
         Order orderToDelete = lastShownList.get(targetIndex.getZeroBased());
-        if (orderToDelete.isAlreadyAssignedDeliveryman() && orderToDelete.getOrderStatus().isOngoingStatus()) {
+        if (orderToDelete.isAlreadyAssignedDeliveryman() && orderToDelete.isOngoing()) {
             throw new CommandException(Messages.MESSAGE_ORDER_HAS_DELIVERYMAN_CANNOT_DELETE);
         }
 

--- a/src/main/java/seedu/address/logic/commands/order/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/order/EditCommand.java
@@ -85,8 +85,13 @@ public class EditCommand extends OrderCommand {
         Order orderToEdit = lastShownList.get(index.getZeroBased());
         Order editedOrder = createEditedOrder(orderToEdit, editOrderDescriptor);
 
+
         if (!orderToEdit.isSameOrder(editedOrder) && model.hasOrder(editedOrder)) {
             throw new CommandException(MESSAGE_DUPLICATE_ORDER);
+        }
+
+        if (editedOrder.isCompleted()) {
+            throw new CommandException(Messages.MESSAGE_COMPLETED_ORDER);
         }
 
         if (editedOrder.isAlreadyAssignedDeliveryman()) {

--- a/src/main/java/seedu/address/model/order/Order.java
+++ b/src/main/java/seedu/address/model/order/Order.java
@@ -125,6 +125,14 @@ public class Order extends TaggedObject {
         return deliveryman != null;
     }
 
+    public boolean isCompleted() {
+        return orderStatus.isCompletedStatus();
+    }
+
+    public boolean isOngoing() {
+        return orderStatus.isOngoingStatus();
+    }
+
     /**
      * Returns true if both orders of the same name have at least one other identity field that is the same.
      * This defines a weaker notion of equality between two orders.

--- a/src/main/java/seedu/address/model/order/OrderStatus.java
+++ b/src/main/java/seedu/address/model/order/OrderStatus.java
@@ -44,6 +44,13 @@ public class OrderStatus {
     }
 
     /**
+     * Checks if the status is completed.
+     */
+    public boolean isCompletedStatus() {
+        return orderState.equals(Status.COMPLETED);
+    }
+
+    /**
      * Returns true if a given string is a valid status.
      */
     public static boolean isValidStatus(String orderStatus) {

--- a/src/test/data/XmlFoodZoomTest/typicalFoodZoom.xml
+++ b/src/test/data/XmlFoodZoomTest/typicalFoodZoom.xml
@@ -31,7 +31,7 @@
             <phone>87652533</phone>
             <address>10th street, 612234</address>
             <date>04-10-2018 10:00:00</date>
-            <status>COMPLETED</status>
+            <status>PENDING</status>
             <food>Fish and Chips</food>
         </orders>
         <orders tag="d0abc707-2363-46b2-8c45-92667f3d9e0e">
@@ -47,7 +47,7 @@
             <phone>9482427</phone>
             <address>little tokyo, 612234</address>
             <date>01-10-2018 10:00:00</date>
-            <status>ONGOING</status>
+            <status>COMPLETED</status>
             <food>Tuna Sandwich</food>
         </orders>
         <orders tag="e7dc53e1-a1a0-4208-8f29-a6b24f215ff9">

--- a/src/test/data/XmlSerializableOrderBookTest/typicalOrdersOrderBook.xml
+++ b/src/test/data/XmlSerializableOrderBookTest/typicalOrdersOrderBook.xml
@@ -31,7 +31,7 @@
         <phone>87652533</phone>
         <address>10th street, 612234</address>
         <date>04-10-2018 10:00:00</date>
-        <status>COMPLETED</status>
+        <status>PENDING</status>
         <food>Fish and Chips</food>
     </orders>
     <orders tag="d0abc707-2363-46b2-8c45-92667f3d9e0e">
@@ -47,7 +47,7 @@
         <phone>9482427</phone>
         <address>little tokyo, 612234</address>
         <date>01-10-2018 10:00:00</date>
-        <status>ONGOING</status>
+        <status>COMPLETED</status>
         <food>Tuna Sandwich</food>
     </orders>
     <orders tag="e7dc53e1-a1a0-4208-8f29-a6b24f215ff9">

--- a/src/test/java/seedu/address/testutil/TypicalOrders.java
+++ b/src/test/java/seedu/address/testutil/TypicalOrders.java
@@ -55,13 +55,13 @@ public class TypicalOrders {
             .withFood("Milkshake").build();
     public static final Order DANIEL = new OrderBuilder().withId(DANIEL_ID).withName("Daniel Meier")
             .withPhone("87652533").withAddress("10th street, 612234").withDate("04-10-2018 10:00:00")
-            .withStatus("COMPLETED").withFood("Fish and Chips").build();
+            .withStatus("PENDING").withFood("Fish and Chips").build();
     public static final Order ELLE = new OrderBuilder().withId(ELLE_ID).withName("Elle Meyer").withPhone("9482224")
             .withAddress("michegan ave, 612234").withDate("05-10-2018 10:00:00").withStatus("PENDING")
             .withFood("Chicken Chop")
             .build();
     public static final Order FIONA = new OrderBuilder().withId(FIONA_ID).withName("Fiona Kunz").withPhone("9482427")
-            .withAddress("little tokyo, 612234").withDate("01-10-2018 10:00:00").withStatus("ONGOING")
+            .withAddress("little tokyo, 612234").withDate("01-10-2018 10:00:00").withStatus("COMPLETED")
             .withFood("Tuna Sandwich")
             .build();
     public static final Order GEORGE = new OrderBuilder().withId(GEORGE_ID).withName("George Best").withPhone("9482442")

--- a/src/test/java/systemtests/FindCommandSystemTest.java
+++ b/src/test/java/systemtests/FindCommandSystemTest.java
@@ -202,9 +202,9 @@ public class FindCommandSystemTest extends OrderBookSystemTest {
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 
-        /* Case: find 2 different statuses of order in order book -> 2 orders found */
+        /* Case: find 2 different statuses of order in order book -> 1 order found */
         command = findCommand + " " + PREFIX_STATUS + "ONGOING COMPLETED";
-        ModelHelper.setFilteredList(expectedModel, DANIEL, FIONA);
+        ModelHelper.setFilteredList(expectedModel, FIONA);
         assertCommandSuccess(command, expectedModel);
         assertSelectedCardUnchanged();
 


### PR DESCRIPTION
Fixes #187 :
- Now, if the user tries to edit a completed order, this is the error message shown:
![image](https://user-images.githubusercontent.com/35655790/48314531-d5bda280-e605-11e8-800d-8c0da3ec1aab.png)

- If the user tries to assign a completed order, same error message is shown:
![image](https://user-images.githubusercontent.com/35655790/48314549-19b0a780-e606-11e8-9d95-7f55ff4f493a.png)

- `/order clear` now works as long as the list does not contain an `Ongoing` order